### PR TITLE
Bugfix in lmax

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SphericalHarmonics"
 uuid = "c489a379-e885-57ff-9236-bd896d33c250"
-version = "0.1.8"
+version = "0.1.9"
 
 [deps]
 ElasticArrays = "fdbdab4c-e67f-52f5-8c3f-e7b388dad3d4"

--- a/src/SphericalHarmonics.jl
+++ b/src/SphericalHarmonics.jl
@@ -429,7 +429,7 @@ function computePlmx!(P::AssociatedLegendrePolynomials, x::Real, lmax::Integer, 
         computePlmx!(parent(P), x, lmax, coeff)
         P.cosθ = x
     end
-    P.lmax = max(P.lmax, lmax)
+    P.lmax = lmax
     P.initialized = true
     return P
 end
@@ -549,7 +549,7 @@ function _computePlmcostheta_alp!(P::AssociatedLegendrePolynomials, θ::Real, lm
         computePlmcostheta!(parent(P), θ, lmax, args...)
         P.cosθ = cos(θ)
     end
-    P.lmax = max(P.lmax, lmax)
+    P.lmax = lmax
     P.initialized = true
     return P
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -737,11 +737,15 @@ end
         S = SphericalHarmonics.cache(3);
         @test S.lmax == 3
         θ, ϕ = pi/3, pi/4
-        SphericalHarmonics.computePlmx!(S, cos(θ), 3)
-        @test S.P == SphericalHarmonics.computePlmx(cos(θ), lmax = 3)
+        SphericalHarmonics.computePlmx!(S, cos(θ), 1)
+        @test S.P.lmax == 1
+        P2 = SphericalHarmonics.computePlmx(cos(θ), lmax = 1)
+        @test S.P[1:length(P2)] == P2
         SphericalHarmonics.computePlmx!(S, cos(2θ))
+        @test S.P.lmax == S.lmax
         @test S.P == SphericalHarmonics.computePlmx(cos(2θ), lmax = 3)
         computePlmcostheta!(S, θ, 3)
+        @test S.lmax == 3
         @test S.P == computePlmcostheta(θ, lmax = 3)
         # This should be a no-op
         computePlmcostheta!(S, θ, 3)


### PR DESCRIPTION
`lmax` in `S::SphericalHarmonicCache` may differ from that in `S.P`. The latter should be set when the polynomials are evaluated.